### PR TITLE
Dead site removal - aroace.space

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -33,14 +33,6 @@
             "siteLongDescription": ""
         },
         {
-            "siteOwner": "Forever",
-            "siteName": "Forever's home",
-            "siteURL": "https://aroace.space/",
-            "siteTags": "",
-            "siteShortDescription": "",
-            "siteLongDescription": ""
-        },
-        {
             "siteOwner": "joe jennet",
             "siteName": "bulltown.2022",
             "siteURL": "https://bulltown.2022.joejenett.com/#rings",


### PR DESCRIPTION
     Removed

   {
            "siteOwner": "Forever",
            "siteName": "Forever's home",
            "siteURL": "https://aroace.space/",
            "siteTags": "",
            "siteShortDescription": "",
            "siteLongDescription": ""
        },